### PR TITLE
Add file based secret support, update README.

### DIFF
--- a/dockerfiles/Dockerfile_3
+++ b/dockerfiles/Dockerfile_3
@@ -1,4 +1,7 @@
-FROM microsoft/dotnet:2.1-sdk AS build-env
+# 
+# builder - first stage to build the application
+# 
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build-env
 WORKDIR /app
 
 # copy csproj and restore as distinct layers
@@ -11,19 +14,51 @@ RUN dotnet publish -c Release -o out
 COPY ./appsettings.*.json /app/out/
 COPY ./appsettings.json /app/out/
 
-# build runtime image
-FROM microsoft/dotnet:2.1-sdk
+# ------------------------------------------------
+
+# 
+# runtime - build final runtime image
+# 
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1-alpine
+
+ARG IMAGE_CREATE_DATE
+ARG IMAGE_VERSION
+ARG IMAGE_SOURCE_REVISION
+
+ENV SQL_USER="sqladmin" \
+    SQL_PASSWORD="changeme" \
+    SQL_SERVER="changeme.database.windows.net" \
+    SQL_DBNAME="mydrivingDB" \
+    WEB_PORT=80 \
+    WEB_SERVER_BASE_URI="http://0.0.0.0" \
+    ASPNETCORE_ENVIRONMENT="Development"
+
+# Metadata as defined in OCI image spec annotations - https://github.com/opencontainers/image-spec/blob/master/annotations.md
+LABEL org.opencontainers.image.title="Trip Insights - POI (Points Of Interest) API" \
+      org.opencontainers.image.description="The POI (Points Of Interest) API component forms part of the Trip Insights application." \
+      org.opencontainers.image.created=$IMAGE_CREATE_DATE \
+      org.opencontainers.image.version=$IMAGE_VERSION \
+      org.opencontainers.image.authors="Microsoft" \
+      org.opencontainers.image.url="https://github.com/vyta/openhack-containers/blob/master/dockerfiles/Dockerfile_3" \
+      org.opencontainers.image.documentation="https://github.com/vyta/openhack-containers/blob/master/src/poi/README.md" \
+      org.opencontainers.image.vendor="Microsoft" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.source="https://github.com/vyta/openhack-containers.git" \
+      org.opencontainers.image.revision=$IMAGE_SOURCE_REVISION 
+
+# add debugging utilities
+RUN apk --no-cache add \
+  curl \
+  ca-certificates \
+  jq \
+  less \
+  vim
+
+# add the application to the container
 WORKDIR /app
-
-ENV SQL_USER="adminuser" \
-SQL_PASSWORD="changeme" \
-SQL_SERVER="changeme.database.windows.net" \
-SQL_DBNAME="mydrivingDB" \
-WEB_PORT="8080" \
-WEB_SERVER_BASE_URI="http://0.0.0.0" \
-ASPNETCORE_ENVIRONMENT="Production"
-
 COPY --from=build-env /app/out .
 
+# run application
+EXPOSE $WEB_PORT
 ENTRYPOINT ["dotnet", "<changeme>.dll"]
 

--- a/src/poi/README.md
+++ b/src/poi/README.md
@@ -1,45 +1,105 @@
 
-# POI Service
+# POI (Points Of Interest) API
 
-## Overview
+This is the POI (Points Of Interest) API for the Trip Insights service. It collects the points of the trip when a hard stop or hard acceleration was detected.
 
-The POI (Point Of Interests) API collects the points of the trip when a hard stop or hard acceleration was detected.
+## Dependencies
 
-## Environment Variables
-
-- SQL_SERVER
-- SQL_DBNAME
-- SQL_USER
-- SQL_PASSWORD
-- WEB_PORT
-- WEB_SERVER_BASE_URI
-- ASPNETCORE_ENVIRONMENT
+The POI (Points Of Interest) API has a dependency on a SQL Server compatible database to store the points of interest.
 
 ## API Paths
 
-- /api/poi
-- /api/healthcheck/poi
-- /api/docs/poi
-- /swagger/docs/poi
+| Method  | Path                       |Description                                                 |
+|---------|----------------------------|------------------------------------------------------------|
+| GET     | /api/poi                   | List all the points of interest                            |
+| GET     | /api/poi/{ID}              | Fetch an existing point of interest                        |
+| POST    | /api/poi                   | Create a new point of interest                             |
+| GET     | /api/poi/trip/{tripID}     | List all the points of interest for the specified trip     |
+| GET     | /api/healthcheck/poi       | Return the healthcheck status for the POI API              |
+| GET     | /api/docs/poi              | Return the OpenAPI documentation for the POI API           |
 
-## Build and run the Application
+## Additional Paths
 
+The following paths must be allowed by any network appliance or gateway that is controlling inbound access to this API. These are all paths the OpenAPI controller will leverage to build its resources.
+
+| Method  | Path                          |Description                            |
+|---------|-------------------------------|---------------------------------------|
+| GET     | /swagger/docs/poi             | Required by the OpenAPI controller    |
+
+## Configuration
+
+The POI (Points Of Interest) API is configured via the variables in the table below.
+
+The value for a configuration variable may be specified via an environment variable (ENV) or as the contents of a file. If the file method is used, then the filename must be the name of the variable. The following describes the additive rules configured via the .NET Core framework for obtaining a configuration value:
+
+1. Default value for configuration variable if it is defined. Example: `sqladmin`
+1. If an environment variable is specified, this overrides the value. Example: `$SQL_USER`
+1. If there is a file located in `/secrets` path, then its contents overrides the value. Example: `/secrets/SQL_USER`
+
+| Name                    | Required | Type        | Default Value  | Description                                       |
+|-------------------------|----------|-------------|----------------|---------------------------------------------------|
+| WEB_SERVER_BASE_URI     | No       | ENV         | http://0.0.0.0 | The url that API service web host will listen on. |
+| WEB_PORT                | No       | ENV         | 80             | The port that the API service will listen on.     |
+| CONFIG_FILES_PATH       | No       | ENV         | /secrets       | The base path for file based variables.           |
+| SQL_USER                | Yes      | ENV or File | sqladmin       | The username for the SQL Server database.         |
+| SQL_PASSWORD            | Yes      | ENV or File |                | The password for the SQL Server database.         |
+| SQL_SERVER              | Yes      | ENV or File |                | The server name for the SQL Server database.      |
+| SQL_DBNAME              | Yes      | ENV or File | mydrivingDB    | The name of the SQL Server database.              |
+| ASPNETCORE_ENVIRONMENT  | No       | ENV         | Development    | The ASP.NET hosting environment setting.          |
+
+## Run in Docker
+
+To build the image
+
+Bash
 ```bash
-dotnet restore
-dotnet build
-dotnet run
+$ docker build --no-cache --build-arg IMAGE_VERSION="1.0" --build-arg IMAGE_CREATE_DATE="`date -u +"%Y-%m-%dT%H:%M:%SZ"`" --build-arg IMAGE_SOURCE_REVISION="`git rev-parse HEAD`" -f Dockerfile -t "tripinsights/poi:1.0" .
 ```
 
-## Tests
+Powershell
+```powershell
+PS> docker build --no-cache --build-arg IMAGE_VERSION="1.0" --build-arg IMAGE_CREATE_DATE="$(Get-Date((Get-Date).ToUniversalTime()) -UFormat '%Y-%m-%dT%H:%M:%SZ')" --build-arg IMAGE_SOURCE_REVISION="$(git rev-parse HEAD)" -f Dockerfile -t "tripinsights/poi:1.0" .
+```
 
-### Running the unit tests
+To run the image
 
-### Running the Integration Test
+```bash
+# Example 1 - Set config values via environment variables
+$ docker run -d -p 8080:80 --name poi -e "SQL_PASSWORD=$SQL_PASSWORD" -e "SQL_SERVER=$SQL_SERVER" -e "ASPNETCORE_ENVIRONMENT=Production" tripinsights/poi:1.0
 
-## References
+# Example 2 - Set configuration via files. Server will expect config values in files like /secrets/SQL_USER.
+# The secrets must be mounted from a host volume (eg. $HOST_FOLDER) into the /secrets container volume.
+$ docker run -d -p 8080:80 --name poi -v $HOST_FOLDER:/secrets -e "ASPNETCORE_ENVIRONMENT=Production" tripinsights/poi:1.0
+```
 
-* [Web API](https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-web-api)
-* [Unit Testing](https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-with-dotnet-test?view=aspnetcore-2.1)
-* [Integration Testing](https://docs.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-2.1)
-* [Example - How to Debug .NET Core Xunit Tests](https://github.com/nickolasacosta/dotnetcore-xunit-debugging)
-* [Logging in ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-2.1&tabs=aspnetcore2x)
+## Testing
+
+List all the points of interest.
+
+```bash
+$ curl -s -X GET 'http://localhost:8080/api/poi' | jq
+```
+
+Fetch an existing point of interest with id `264ffaa3-1fe8-4fb0-a4fb-63bdbc9999ae`.
+
+```bash
+$ curl -s -X GET 'http://localhost:8080/api/poi/264ffaa3-1fe8-4fb0-a4fb-63bdbc9999ae' | jq
+```
+
+Create a new point of interest for a `HardBrake` (poiType=2) event. The id will be autogenerated and returned.
+
+```bash
+$ curl -s -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{ "tripId": "ea2f7ae0-3cef-49cb-b7d1-ce972113120c", "latitude": 47.39026323526123, "longitude": -123.23165568111123, "poiType": 2, "timestamp": "2019-07-12T02:30:03.351Z", "deleted": false }' 'http://localhost:8080/api/poi' | jq
+```
+
+List all the points of interest for the specified trip with id `ea2f7ae0-3cef-49cb-b7d1-ce972113120c`.
+
+```bash
+$ curl -s -X GET 'http://localhost:8080/api/poi/trip/ea2f7ae0-3cef-49cb-b7d1-ce972113120c' | jq
+```
+
+Get healthcheck status
+
+```bash
+$ curl -s -X GET 'http://localhost:8080/api/healthcheck/poi' | jq
+```

--- a/src/poi/web/Program.cs
+++ b/src/poi/web/Program.cs
@@ -27,8 +27,8 @@ namespace poi
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) {
             //used to read env variables for host/port
             var configuration = new ConfigurationBuilder()
-            .AddEnvironmentVariables()
-            .Build();
+                .AddEnvironmentVariables()
+                .Build();
 
             var host = new WebHostBuilder()
                 .UseKestrel()
@@ -48,6 +48,7 @@ namespace poi
                     config.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
                     config.AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true);
                     config.AddEnvironmentVariables();
+                    config.AddKeyPerFile(directoryPath: "/secrets", optional: true);
                     config.AddCommandLine(args);
                 })
                 .UseStartup<Startup>()

--- a/src/poi/web/Startup.cs
+++ b/src/poi/web/Startup.cs
@@ -43,7 +43,7 @@ namespace poi
             // Register the Swagger generator, defining 1 or more Swagger documents
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("docs", new Info { Title = "Points Of Interest(POI) API", Version = "v1" });
+                c.SwaggerDoc("docs", new Info { Title = "Trip Insights Points Of Interest (POI) API", Description = "API for the trips in the Trip Insights app. https://github.com/vyta/openhack-containers", Version = "v1" });
             });
         }
 
@@ -67,7 +67,7 @@ namespace poi
             // specifying the Swagger JSON endpoint.
             app.UseSwaggerUI(c =>
             {
-                c.SwaggerEndpoint("/swagger/docs/poi/swagger.json", "Points Of Interest(POI) API V1");
+                c.SwaggerEndpoint("/swagger/docs/poi/swagger.json", "Trip Insights Points Of Interest (POI) API V1");
                 c.DocumentTitle = "POI Swagger UI";
                 c.RoutePrefix = "api/docs/poi";
             });


### PR DESCRIPTION
POI API now has

- file based secrets (precedence described in README)
- updated README with curl examples for all endpoints
- all endpoints tested against database and working
- updated base images referenced from new official registry for Microsoft images - mcr.microsoft.com
- smaller image size - 1.8GB -> 200MB by using aspnet runtime base image not sdk for final image