### PR TITLE
Change SQL_USER to sa

### DIFF
--- a/dockerfiles/Dockerfile_0
+++ b/dockerfiles/Dockerfile_0
@@ -12,7 +12,7 @@ ARG IMAGE_VERSION
 ARG IMAGE_SOURCE_REVISION
 
 ENV PORT=80 \
-    SQL_USER="sqladmin" \
+    SQL_USER="sa" \
     SQL_PASSWORD="changeme" \
     SQL_SERVER="changeme.database.windows.net" \
     SQL_DBNAME="mydrivingDB"

--- a/dockerfiles/Dockerfile_2
+++ b/dockerfiles/Dockerfile_2
@@ -6,7 +6,7 @@ ARG IMAGE_SOURCE_REVISION
 
 ENV PORT=80 \
     CONFIG_FILES_PATH="/secrets" \
-    SQL_USER="sqladmin" \
+    SQL_USER="sa" \
     SQL_PASSWORD="changeme" \
     SQL_SERVER="changeme.database.windows.net" \
     SQL_DBNAME="mydrivingDB"

--- a/dockerfiles/Dockerfile_3
+++ b/dockerfiles/Dockerfile_3
@@ -43,7 +43,7 @@ ARG IMAGE_CREATE_DATE
 ARG IMAGE_VERSION
 ARG IMAGE_SOURCE_REVISION
 
-ENV SQL_USER="sqladmin" \
+ENV SQL_USER="sa" \
     SQL_PASSWORD="changeme" \
     SQL_SERVER="changeme.database.windows.net" \
     SQL_DBNAME="mydrivingDB" \

--- a/dockerfiles/Dockerfile_4
+++ b/dockerfiles/Dockerfile_4
@@ -17,7 +17,7 @@ ARG IMAGE_SOURCE_REVISION
 
 ENV PORT="80" \
     CONFIG_FILES_PATH="/secrets" \
-    SQL_USER="sqladmin" \
+    SQL_USER="sa" \
     SQL_PASSWORD="changeme" \
     SQL_SERVER="changeme.database.windows.net" \
     SQL_DBNAME="mydrivingDB" \


### PR DESCRIPTION
I could not get the containers to run without `SQL_USER` being set to "sa." I think this is an important change because it is hinted at that the other environment variables should be changed, but not that `SQL_USER` should be.