### PR TITLE
Update the @hapi/hoek version in userprofile.json

### DIFF
--- a/src/userprofile/package.json
+++ b/src/userprofile/package.json
@@ -9,7 +9,7 @@
     "license": "UNLICENSED",
     "bugs": "http://github.com/Azure-Samples/openhack-devops-team/issues",
     "dependencies": {
-        "@hapi/hoek": "^7.1.0",
+        "@hapi/hoek": "^7.2.1",
         "@hapi/joi": "^15.0.3",
         "body-parser": "^1.19.0",
         "enjoi": "^4.0.0",


### PR DESCRIPTION
On docker build, you get the set of red warnings:
npm WARN deprecated @hapi/hoek@7.2.1: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to  features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).